### PR TITLE
removed comment about sbbbsexec.dll

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,6 @@
             <h2><a name="download"></a>Download</h2>
             <ul>
               <li><a href="http://build.wwiv.us/job/WWIV/">Nightly Builds</a></li>
-                <li>Download source to SBBSEXEC (GPL)</a></li>
             </ul>    
             <h2><a name="IRC"></a>Join us on IRC</h2>
             <p>The dev team and fellow SysOps hangs out on IRC at: <br/>


### PR DESCRIPTION
Its now in the builds. No need to call it out.
