### PR TITLE
correcting docs url

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
 	  <div class="panel-heading">Get WWIV</div>
       <div class="panel-body">
       	<P><a href="http://docs.wwivbbs.org/en/latest/WWIV_BBS_list/">WWIV BBS List</a></P>
-      <p><a href="http://wwivbbs.readthedocs.org/en/latest/#get-wwiv-50">Download and Install WWIV 5.0.0</a></p>
-      <p><a href="https://wwivbbs.readthedocs.org">WWIV Documentation</a></li></p>
+      <p><a href="http://docs.wwivbbs.org/en/latest/#get-wwiv-50">Download and Install WWIV 5.0.0</a></p>
+      <p><a href="https://docs.wwivbbs.org">WWIV Documentation</a></li></p>
       </div>
     </div>
     </div>
@@ -90,7 +90,7 @@
           <li><a href="#IRC">Join us on IRC</a></li>
           <li><a href="https://build.wwivbbs.org/jenkins/">Nightly Builds</a></li>
           <li><a href="https://github.com/wwivbbs/wwiv">GitHub Project</a></li>
-          <li><a href="http://wwivbbs.readthedocs.org/en/latest/license/">License</a></li>
+          <li><a href="http://docs.wwivbbs.org/en/latest/license/">License</a></li>
           <li><a href="https://github.com/wwivbbs/wwiv/issues">Bug Reports</a></li>
           <li><a href="https://github.com/wwivbbs/wwiv/labels/enhancement">Feature Requests</a></li>
         </ul>    


### PR DESCRIPTION
the old wwivbbs.readthedocs.org url was replaced with docs.wwivbbs.org
